### PR TITLE
Preserve Contact Form Input

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ It also includes some config linters for (`HTML` / `CSS3` / `JavaScript`) in the
 - Details Popup window for browsing each project
 - Navigation buttons inside popup window
 - Custom form validation in contact form
+- Preserving contact form information in browser
 
 <p align="right"><a href="#title">back to top</a></p>
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -549,8 +549,9 @@ a {
   font: 1rem/2rem var(--primary-font-bold);
 }
 
-.contact .button {
-  align-self: center;
+.contact-controls {
+  display: flex;
+  justify-content: space-between;
 }
 
 .footer-socials {
@@ -639,7 +640,8 @@ a {
   .about-banner,
   .about-list,
   .contact,
-  .contact form {
+  .contact form,
+  .contact-controls {
     gap: 24px;
   }
 
@@ -814,8 +816,8 @@ a {
     width: 50%;
   }
 
-  .contact .button {
-    align-self: flex-start;
+  .contact-controls {
+    justify-content: flex-start;
   }
 
   .socials img:hover,

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,4 +1,5 @@
 let projectIndex = null;
+let formValues = { name: '', email: '', message: '' };
 const worksGrid = document.querySelector('.works-grid');
 const worksPopup = document.querySelector('.works-popup');
 const headerMenu = document.querySelector('.header-menu-links');
@@ -177,6 +178,14 @@ function validateFields() {
     contactMessage.textContent = '';
   }
 }
+function fillForm() {
+  if (localStorage.getItem('formValues') !== null) {
+    formValues = JSON.parse(localStorage.getItem('formValues'));
+  }
+  Object.keys(formValues).forEach((key) => {
+    contactForm[key].value = formValues[key];
+  });
+}
 function submitForm(event) {
   event.preventDefault();
   validateFields();
@@ -189,6 +198,18 @@ function submitForm(event) {
     contactMessage.classList.add('visibility');
   }
 }
+function storeForm(event) {
+  if (event.target.name in formValues) {
+    formValues[event.target.name] = event.target.value;
+    localStorage.setItem('formValues', JSON.stringify(formValues));
+  }
+}
+function clearForm() {
+  localStorage.clear();
+  if (contactMessage.classList.contains('visibility')) {
+    contactMessage.classList.remove('visibility');
+  }
+}
 worksGrid.addEventListener('click', openPopup);
 popupClose.addEventListener('click', closePopup);
 headerMenu.addEventListener('click', toggleMenu);
@@ -196,7 +217,10 @@ headerButton.addEventListener('click', toggleMenu);
 popupControls[0].addEventListener('click', previousPopup);
 popupControls[1].addEventListener('click', nextPopup);
 contactForm.addEventListener('submit', submitForm);
+contactForm.addEventListener('change', storeForm);
+contactForm.addEventListener('reset', clearForm);
 window.addEventListener('scroll', pageScroll);
 headerlinks.shift();
 headerlinks.pop();
 fillGrid();
+fillForm();

--- a/index.html
+++ b/index.html
@@ -157,7 +157,10 @@
               <textarea name="message" placeholder="Write me something..." maxlength="500" required></textarea>
             </label>
             <small></small>
-            <button class="button" type="submit">Get in touch</button>
+            <div class="contact-controls">
+              <button class="button" type="submit">Get in touch</button>
+              <button class="button" type="reset">Clear fields</button>
+            </div>
           </form>
         </div>
       </section>


### PR DESCRIPTION
- Storing any user input in the browser `localStorage`
- Implemented `change` listeners to detect any changes in input fields
- Added a function called `fillForm` to populate the contact form
- Created a button with `reset` attribute to reset the form and clear the browser `localStorage`